### PR TITLE
hotfix - exported script names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,5 @@ build-backend = "poetry.masonry.api"
 [tool.poetry.scripts]
 fave-extract = "fave.extractFormants:main"
 fave-align = "fave.FAAValign:setup"
+extractFormants = "fave.extractFormants:main"
+FAAValign = "fave.FAAValign:setup"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ version = "2.0.1"
 description = "Forced alignment and vowel extraction"
 authors = ["FAVE contributors"]
 license = "GPL-3.0-only"
+readme = "README.rst"
+homepage = "https://github.com/JoFrhwld/FAVE"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"


### PR DESCRIPTION
In an earlier commit, I changed the name of the exported scripts

~`extractFormants`~ -> `fave-extract`
~`FAAValign`~ -> `fave-align`

But this wasn't documented, and there's no issue with exporting both.


