### PR TITLE
Deprecations, restore test files, new module

### DIFF
--- a/fave/parselmouth_bridge.py
+++ b/fave/parselmouth_bridge.py
@@ -1,0 +1,147 @@
+import parselmouth
+from deprecated.sphinx import versionadded
+
+@versionadded(version="2.1")
+class Formant():
+    """Bridge the parselmouth.Formant API with our scripting needs.
+    """
+    def __init__(self, formant_obj, maxFormant):
+        """Create an instance from a parselmouth.Formant instance
+        
+        :param formant_obj: A parselmouth.Formant instance.
+        :param maxFormant: Currently unused
+        """
+        self.__pm_formant = formant_obj
+        self.__maxFormant = maxFormant
+        self.intensities = []
+    
+    def __formant_iter( self, function, range_ ):
+        """Takes a callback function from parselmouth.Formant and applies a loop
+
+        :param function: A parselmouth.Formant method which will be called in this loop.
+        :type function: function
+        :param range_: A tuple or list passed to `range()` specifying which formants to loop over.
+            N.B. `range_` is inclusive on the lower bound, exclusive on the upper bound, so (1,4) will 
+            give formants 1 through 3, and not 4.
+        :type range_: tuple|list
+        :return: The measures output by the callback function. Each list item is a list of formant
+            measurements for the given time input.
+        :rtype: list
+        """
+        ret = []
+        for t in self.times():
+            vals = []
+            for n in range(*range_):
+                vals.append( function(formant_number = n, time = t) )
+            ret.append(vals)
+        return ret
+
+    def times(self):
+        """Wrapper around parselmouth.Formant.ts
+
+        :rtype: list
+        """
+        return list(self.__pm_formant.ts())
+
+    def formants(self, range_ = (1,4)):
+        """Returns formant measures at each time point.
+
+        :param range_: The range of formants to measure passed to `range()`, defaults to (1,4).
+            N.B. `range_` is inclusive on the lower bound, exclusive on the upper bound, so (1,4) will 
+            give formants 1 through 3, and not 4.
+        :type range_: tuple|list
+        :return: Formant measurements. Each list item is a list of formant
+            measurements for the given time input.
+        :rtype: list
+        """
+        return self.__formant_iter(
+                self.__pm_formant.get_value_at_time,
+                range_
+            )
+
+    def bandwidths(self, range_ = (1,4)):
+        """Returns formant bandwidth measures at each time point.
+
+        :param range_: The range of formants to measure passed to `range()`, defaults to (1,4).
+            N.B. `range_` is inclusive on the lower bound, exclusive on the upper bound, so (1,4) will 
+            give formants 1 through 3, and not 4.
+        :type range_: tuple|list
+        :return: Bandwidth measurements. Each list item is a list of bandwidth
+            measurements for the given time input.
+        :rtype: list
+        """
+        return self.__formant_iter(
+                self.__pm_formant.get_bandwidth_at_time,
+                range_
+            )
+
+    def xmin(self):
+        """Wrapper around parselmouth.Formant.xmin
+
+        :rtype: float?
+        """
+        return self.__pm_formant.xmin
+    
+    def xmax(self):
+        """Wrapper around parselmouth.Formant.xmax
+
+        :rtype: float?
+        """
+        return self.__pm_formant.xmax
+
+    def n(self):
+        """Wrapper around parselmouth.Formant.nx
+
+        :rtype: int?
+        """
+        return self.__pm_formant.nx
+
+    @property
+    def intensities(self):
+        return self.__intensities
+
+@versionadded(version="2.1")
+class Intensity():
+    def __init__(self, pm_intensity):
+        self.__pm_intensity = pm_intensity
+        self.offset = 0
+
+    def xmin(self):
+        return self.__pm_intensity.xmin + self.offset
+
+    def xmax(self):
+        return self.__pm_intensity.xmax + self.offset
+
+    def n(self):
+        return self.__pm_intensity.n
+
+    def nx(self):
+        return self.__pm_intensity.nx
+
+    def dx(self):
+        return self.__pm_intensity.dx
+
+    def x1(self):
+        return self.__pm_intensity.x1 + self.offset
+
+    def times(self):
+        return [x + self.offset for x in list(self.__pm_intensity.ts())]
+
+    def intensities(self):
+        return [self.__pm_intensity.get_value(time = t) for t in self.times()]
+
+    def change_offset(self, offset):
+        self.offset = offset
+
+    def __str__(self):
+        return '<Intensity object with %i frames>' % self.__n
+
+    def __iter__(self):
+        return iter(self.__intensities)
+
+    def __len__(self):
+        return self.__n
+
+    def __getitem__(self, i):
+        """returns the (i+1)th intensity frame"""
+        return self.intensities()[i]

--- a/fave/praat.py
+++ b/fave/praat.py
@@ -1,36 +1,16 @@
 import parselmouth
+from deprecated.sphinx import deprecated
 
-class Formant:
+from fave import parselmouth_bridge as pm_bridge
 
+@deprecated(version="2.1",reason="fave.praat.Formant is deprecated in favor of fave.parselmouth_bridge.")
+class Formant():
     """represents a formant contour as a series of frames"""
-
     def __init__(self, name=None, formant = None, maxFormant = None):
-        if formant and maxFormant:
-            if isinstance(formant, parselmouth.Formant):
-                self.__times = list(formant.ts())  # list of measurement times (frames)
-                self.__intensities = []
-                    # list of intensities (maximum intensity in each frame)
-                self.__formants = [[formant.get_value_at_time(formant_number = N, time = T) 
-                                      for N in (1,2,3) ]  
-                                    for T in formant.ts()]
-                    # list of formants frequencies (F1-F3, for each frame)
-                self.__bandwidths = [[formant.get_bandwidth_at_time(formant_number = N, time = T) 
-                                        for N in (1,2,3)] 
-                                    for T in formant.ts()]
-                    # list of bandwidths (for each formant F1-F3, for each frame)
-                                            # !!! CHANGED:  all above lists no longer include frames with only
-                                            # a minimum of 2 formant measurements
-                                            # !!!
-                self.__xmin = formant.xmin  # start time (in seconds)
-                self.__xmax = formant.xmax  # end time (in seconds)
-                self.__nx = formant.nx  # number of frames
-                self.__dx = formant.dx  # time step = frame duration (in seconds)
-                self.__x1 = formant.x1  # start time of first frame (in seconds)
-                self.__maxFormants = maxFormant  # maximum number of formants in a frame
-            else:
-                self.blanks()
-        else:
-            self.blanks()
+        self.blanks()  # Set empty by default
+        if isinstance(formant, parselmouth.Formant):
+            pm_formant = pm_bridge.Formant(formant, maxFormant)
+            self.__dict__ = pm_formant.__dict__ # replace this instance with the pm_bridge
 
     def blanks(self):
         """empty entries"""
@@ -167,7 +147,6 @@ class Formant:
 
 
 class LPC:
-
     """represents a Praat LPC (linear predictive coding) object"""
 
     def __init__(self):
@@ -307,29 +286,22 @@ class MFCC:
         text.close()
 
 
+@deprecated(version="2.1",reason="fave.praat.Intensity is deprecated in favor of fave.parselmouth_bridge.")
 class Intensity:
-
     """represents an intensity contour"""
-
     def __init__(self, intensity = None):
         if intensity and isinstance(intensity, parselmouth.Intensity):
-            self.__xmin = intensity.xmin
-            self.__xmax = intensity.xmax
-            self.__n = intensity.nx
-            self.__nx = intensity.nx
-            self.__dx = intensity.dx
-            self.__x1 = intensity.x1
-            self.__times = list(intensity.ts())
-            self.__intensities = [intensity.get_value(time = T) for T in intensity.ts()]
-        else:
-            self.__xmin = None
-            self.__xmax = None
-            self.__n = None
-            self.__nx = None
-            self.__dx = None
-            self.__x1 = None
-            self.__times = []
-            self.__intensities = []
+            pmi = pm_bridge.Intensity(intensity)
+            self.__dict__ = pmi.__dict__
+            return
+        self.__xmin = None
+        self.__xmax = None
+        self.__n = None
+        self.__nx = None
+        self.__dx = None
+        self.__x1 = None
+        self.__times = []
+        self.__intensities = []
 
     def __str__(self):
         return '<Intensity object with %i frames>' % self.__n

--- a/tests/fave/align/test_transcriptprocessor.py
+++ b/tests/fave/align/test_transcriptprocessor.py
@@ -1,5 +1,27 @@
+import logging
 import pytest
 from fave.align import transcriptprocessor
+from fave import cmudictionary # We shouldn't be doing this...
+
+# Copied from ../test_cmudictionary.py
+#  which means this really should be made a fixture...
+KWARGS = {
+        'verbose': 1
+    }
+
+CMU_EXCERPT = """
+TEST  T EH1 S T 
+TEST'S  T EH1 S T S 
+TESTA  T EH1 S T AH0 
+TESTAMENT  T EH1 S T AH0 M AH0 N T 
+TESTAMENTARY  T EH2 S T AH0 M EH1 N T ER0 IY0 
+TESTED  T EH1 S T AH0 D 
+TESTER  T EH1 S T ER0 
+TESTERMAN  T EH1 S T ER0 M AH0 N 
+TESTERS  T EH1 S T ER0 Z 
+TESTERS  T EH1 S T AH0 Z 
+"""
+
 
 def test_replace_smart_quotes():
     def test_func( testcase ):
@@ -69,3 +91,57 @@ def provide_check_transcription_format_raises_value_error():
                                                # Skip 5 entries (not an error)
             [ 'a\tb\tc\td\te\tf', ValueError], # 6 entries
         ]
+
+def test_read_transcription_file(tmp_path):
+    tmp_directory = tmp_path / "transcripts"
+    tmp_directory.mkdir()
+    tmp_file = tmp_directory / "test_transcript.csv"
+    dict_file = tmp_directory / "cmu.dict"
+    dict_file.write_text(CMU_EXCERPT)
+    cmu_dict = cmudictionary.CMU_Dictionary(dict_file, **KWARGS)
+    for test_case in provide_value_error_file():
+        test_text = test_case[0]
+        flags = test_case[1]
+        expected = test_case[2]
+        tmp_file.write_text(test_text)
+        tp_obj = transcriptprocessor.TranscriptProcessor(
+                tmp_file,
+                cmu_dict,
+                **flags
+            )
+        tp_obj.read_transcription_file()
+
+        assert tp_obj.lines == expected
+
+def provide_value_error_file():
+    return [
+        [   # header row is detected and deleted
+            "Style\tSpeaker\tBeginning\tEnd\tDuration\nFoo\tBar\t0.0\t3.2\t3.2",
+            {
+                'prompt': "IDK what this is -CJB",
+                'check' : '',
+                'verbose': logging.DEBUG
+            },
+            ['Foo\tBar\t0.0\t3.2\t3.2']
+        ],
+        [   # test with one line 
+            "Foo\tBar\t0.0\t3.2\t3.2\nTest\t1.0\t4.5\t3.5",
+            {
+                'prompt': "IDK what this is -CJB",
+                'check' : '',
+                'verbose': logging.DEBUG
+            },
+            ['Foo\tBar\t0.0\t3.2\t3.2\n', 'Test\t1.0\t4.5\t3.5']
+        ],
+        [   # test with more lines 
+            "Foo\tBar\t0.0\t3.2\t3.2\nTest\t1.0\t4.5\t3.5\nTest\t1.0\t4.5\t3.5",
+            {
+                'prompt': "IDK what this is -CJB",
+                'check' : '',
+                'verbose': logging.DEBUG
+            },
+            ['Foo\tBar\t0.0\t3.2\t3.2\n', 'Test\t1.0\t4.5\t3.5\n', 'Test\t1.0\t4.5\t3.5']
+        ]
+
+    ]
+

--- a/tests/fave/extract/test_extractFormants.py
+++ b/tests/fave/extract/test_extractFormants.py
@@ -1,0 +1,58 @@
+
+from cmath import nan
+import logging
+import pytest
+import numpy as np
+from fave import extractFormants
+
+def test_mean_stdv():
+    for test_case in provide_valuelist():
+        mean, stdv = extractFormants.mean_stdv(test_case[0])
+        
+        assert mean == test_case[1]
+        assert stdv == test_case[2]
+
+def provide_valuelist():
+    return [  
+        [
+            [1, 2, 3, 4],
+            np.mean([1, 2, 3, 4]),
+            np.std([1, 2, 3, 4], ddof=1)
+        ],
+        [
+            [3.5, 2.6, 11.6, 34.66, 2.8, 4.7],
+            np.mean([3.5, 2.6, 11.6, 34.66, 2.8, 4.7]),
+            np.std([3.5, 2.6, 11.6, 34.66, 2.8, 4.7], ddof=1)
+        ],
+        [
+            [],
+            None,
+            None
+        ],
+        [
+            [23, 34, 45, 56, 12, 312, 45, 943, 21, 1, 4, 6, 9, 2],
+            np.mean([23, 34, 45, 56, 12, 312, 45, 943, 21, 1, 4, 6, 9, 2]),
+            np.std([23, 34, 45, 56, 12, 312, 45, 943, 21, 1, 4, 6, 9, 2], ddof=1)
+        ],
+        [
+            [3],
+            np.mean([3]),
+            0
+        ],
+        [
+            [-1],
+            np.mean([-1]),
+            0
+        ],
+        [
+            [3.5, 2.6, 11.6, None, 34.66, 2.8, 4.7],
+            np.nanmean(np.array([3.5, 2.6, 11.6, None, 34.66, 2.8, 4.7], 
+                                dtype=np.float64)),
+            np.nanstd(np.array([3.5, 2.6, 11.6, None, 34.66, 2.8, 4.7], 
+                               dtype=np.float64),
+                      ddof=1)
+        ]
+    ]
+
+    
+


### PR DESCRIPTION
* Deprecates the sox- and praat-related methods previously removed.
* Restores some test files that seem to have been accidentally removed.
* Adds `parselmouth_bridge` as the new home for parselmouth-related code, moving it out of the praat module (see #87 and #88)